### PR TITLE
Experimental/tls tx retry on eagain

### DIFF
--- a/subsys/net/lib/sockets/Kconfig
+++ b/subsys/net/lib/sockets/Kconfig
@@ -133,6 +133,23 @@ config NET_SOCKETS_TLS_MAX_APP_PROTOCOLS
 	  protocols over TLS/DTL that can be set explicitly by a socket option.
 	  By default, no supported application layer protocol is set.
 
+config NET_SOCKETS_TLS_TX_RETRY_WARN_LEVEL
+	int "Threshold of TX retries that produce a warning"
+	default 100
+	depends on NET_SOCKETS_SOCKOPT_TLS
+	help
+          This variable sets the number of TX retries that that will trigger
+          a warning instead of an info log entry.
+
+config NET_SOCKETS_TLS_TX_MAX_RETRY_LEVEL
+	int "Maximum number of TX retries to attempt"
+	default 500
+	depends on NET_SOCKETS_SOCKOPT_TLS
+	help
+          This variable sets the maximum number of TX retries that happen
+          before the failure is passed to upper layers. Such a maximum is
+          needed as a circuit breaker to avoid endless loops.
+
 config NET_SOCKETS_OFFLOAD
 	bool "Offload Socket APIs [EXPERIMENTAL]"
 	help

--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -615,9 +615,9 @@ static int tls_tx(void *ctx, const unsigned char *buf, size_t len)
 		sent = zsock_sendto(tls_ctx->sock, buf, len,
 		                    tls_ctx->flags, NULL, 0);
 		retrycount++;
-	} while (sent < 0 && errno == EAGAIN && retrycount < 500);
+	} while (sent < 0 && errno == EAGAIN && retrycount < CONFIG_NET_SOCKETS_TLS_TX_MAX_RETRY_LEVEL);
 
-	if (retrycount > 100) {
+	if (retrycount > CONFIG_NET_SOCKETS_TLS_TX_RETRY_WARN_LEVEL) {
 		LOG_WRN("Retried %d times to send packet.", retrycount);
 	} else if (retrycount > 1) {
 		LOG_INF("Retried %d times to send packet.", retrycount);

--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -597,17 +597,36 @@ static int tls_tx(void *ctx, const unsigned char *buf, size_t len)
 	ssize_t sent;
 	size_t retrycount = 0;
 
+	/* If the network is slow and therefore the send window
+	 * is full we receive EAGAIN. The mbedTLS stack forwards
+	 * this information to the application in order to repeat
+	 * the send request. This is correct behavior from Zephyr
+	 * and mbedTLS.
+	 *
+	 * Problem: The application can only resent the complete
+	 * data and not just the remaining unsent data, which
+	 * leads to the same problem again.
+	 *
+	 * Workaround: Try resends here for the remaining data
+	 * here until we have solved the problem of slow network
+	 * speed and/or larger send window sizes.
+	 */
 	do {
 		sent = zsock_sendto(tls_ctx->sock, buf, len,
 		                    tls_ctx->flags, NULL, 0);
 		retrycount++;
-	} while (sent < 0 && errno == EAGAIN);
+	} while (sent < 0 && errno == EAGAIN && retrycount < 500);
 
-	if (retrycount > 1) {
+	if (retrycount > 100) {
+		LOG_WRN("Retried %d times to send packet.", retrycount);
+	} else if (retrycount > 1) {
 		LOG_INF("Retried %d times to send packet.", retrycount);
 	}
 
 	if (sent < 0) {
+		if (errno == EAGAIN) {
+			return MBEDTLS_ERR_SSL_WANT_WRITE;
+		}
 		return MBEDTLS_ERR_NET_SEND_FAILED;
 	}
 


### PR DESCRIPTION
This workaround allows for sending large POST requests through mbedtls altough the TCP TX window is small and always full with POST requests larger than approx. 1.5kByte.