### PR TITLE
This fixes system crashes (restarts without even zephyr fatal) because of null dereferencing

### DIFF
--- a/subsys/shell/shell_log_backend.c
+++ b/subsys/shell/shell_log_backend.c
@@ -318,7 +318,9 @@ static void dropped(const struct log_backend *const backend, uint32_t cnt)
 	const struct shell *shell = (const struct shell *)backend->cb->ctx;
 	const struct shell_log_backend *log_backend = shell->log_backend;
 
-	atomic_add(&shell->stats->log_lost_cnt, cnt);
+	if (IS_ENABLED(CONFIG_SHELL_STATS)) {
+		atomic_add(&shell->stats->log_lost_cnt, cnt);
+	}
 	atomic_add(&log_backend->control_block->dropped_cnt, cnt);
 }
 


### PR DESCRIPTION
When we have a lot of logs, device crashes (restart without even Zephyr Fatal)
Reason is NULL dereferencing of statistics data when dropping logs.

Reproducing:
1. Log a lot via shell backend with deferred logging enabled (I could easily reproduce it when logging all requests to SD card from webserver)
2. Do not turn on CONFIG_SHELL_STATS
3. Enjoy spontaneous reboots 

This issue is already reported in Zephyr (I was late with it...)
Issue in Zephyr: https://github.com/zephyrproject-rtos/zephyr/issues/44089
Fix in Zephyr which I'm cherry-picking here: https://github.com/zephyrproject-rtos/zephyr/pull/44090

I also find it meaningful on CONFIG_SHELL_STATS because then we see how many logs were dropped. 
