### PR TITLE
Hotfix/469 data buffer allocation

### DIFF
--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -1109,6 +1109,8 @@ static void tcp_resend_data(struct k_work *work)
 	bool conn_unref = false;
 	int ret;
 
+	k_mutex_lock(&conn->context->lock, K_FOREVER);
+
 	k_mutex_lock(&conn->lock, K_FOREVER);
 
 	NET_DBG("send_data_retries=%hu", conn->send_data_retries);
@@ -1154,6 +1156,8 @@ static void tcp_resend_data(struct k_work *work)
 
  out:
 	k_mutex_unlock(&conn->lock);
+
+	k_mutex_unlock(&conn->context->lock);
 
 	if (conn_unref) {
 		tcp_conn_unref(conn);


### PR DESCRIPTION
This fixes TX case of infinite Data buffer allocation and dead TCP communication.


It eliminates race condition: https://github.com/zephyrproject-rtos/zephyr/pull/45437

Some more details: https://confluence.zuehlke.com/display/ENDHAU/Data+buffer+allocation+failed%3A+down+the+rabbit+hole
