### PR TITLE
Hotfix/ehlpxt 315 tls vodafone connections leak

### DIFF
--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -2432,7 +2432,7 @@ next_state:
 			next = TCP_FIN_WAIT_2;
 		} else if (th && (len > 0)) {
 			tcp_send_timer_cancel(conn);
-			tcp_out(conn, FIN | ACK);
+			tcp_out_ext(conn, (FIN | ACK), NULL, conn->seq - 1);
 		}
 		break;
 	case TCP_FIN_WAIT_2:

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -2431,7 +2431,8 @@ next_state:
 			tcp_send_timer_cancel(conn);
 			next = TCP_FIN_WAIT_2;
 		} else if (th && (len > 0)) {
-				tcp_out(conn, FIN | ACK);
+			tcp_send_timer_cancel(conn);
+			tcp_out(conn, FIN | ACK);
 		}
 		break;
 	case TCP_FIN_WAIT_2:

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -2430,19 +2430,40 @@ next_state:
 		} else if (th && FL(&fl, ==, ACK, th_seq(th) == conn->ack)) {
 			tcp_send_timer_cancel(conn);
 			next = TCP_FIN_WAIT_2;
+		} else if (th && (len > 0)) {
+				tcp_out(conn, FIN | ACK);
 		}
 		break;
 	case TCP_FIN_WAIT_2:
-		if (th && (FL(&fl, ==, FIN, th_seq(th) == conn->ack) ||
-			   FL(&fl, ==, FIN | ACK, th_seq(th) == conn->ack) ||
-			   FL(&fl, ==, FIN | PSH | ACK,
-			      th_seq(th) == conn->ack))) {
-			/* Received FIN on FIN_WAIT_2, so cancel the timer */
-			k_work_cancel_delayable(&conn->fin_timer);
+		/* Acknowledge but drop any data, but subtract any duplicate data */
+		if (th) {
+			if (len > 0) {
+				int32_t new_len = len - net_tcp_seq_cmp(conn->ack, th_seq(th));
+				/* Cases:
+				 * - Data already received earlier: len > 0 , new_len <= 0
+				 * - Partially new data len > 0, new_len > 0
+				 * - Out of order data len > 0, new_len > 0, ignore the data in
+				 *   between
+				 */
+				if (new_len > 0) {
+					conn_ack(conn, + new_len);
+				}
+			}
 
-			conn_ack(conn, + 1);
-			tcp_out(conn, ACK);
-			next = TCP_TIME_WAIT;
+			if (FL(&fl, ==, FIN, th_seq(th) == conn->ack) ||
+				   FL(&fl, ==, FIN | ACK, th_seq(th) == conn->ack) ||
+				   FL(&fl, ==, FIN | PSH | ACK,
+				      th_seq(th) == conn->ack)) {
+				/* Received FIN on FIN_WAIT_2, so cancel the timer */
+				k_work_cancel_delayable(&conn->fin_timer);
+
+				conn_ack(conn, + 1);
+				tcp_out(conn, ACK);
+				next = TCP_TIME_WAIT;
+			} else if (len > 0) {
+				/* Send out a duplicate ACK */
+				tcp_out(conn,  ACK);
+			}
 		}
 		break;
 	case TCP_CLOSING:


### PR DESCRIPTION
**TL;DR**
Cherry-pick part of https://github.com/zephyrproject-rtos/zephyr/pull/57509, acknowledging data from the host which are received after we sent FIN.

**Problem summary**
It was observed that with some connections (e.g. via Vodafone SIM with Vodafone APN) device stops sending data after a couple of minutes.
Symptom is - can not open socket.

**Investigation**
Further debugging showed that all connections, i.e. sockets were in use, since they had not been closed.

Then wireshark traces were collected.
For that Vodafone SIM (not same as by client, different one) was inserted in Teltonika router. Router then was connected to a MAC, which created an own Wi-Fi network, to which device was connected.

Logs showed that connection was never closed, and stayed in TCP_FIN_WAIT_2 state - host was acknowledging our FIN, but kept sending data. So we never closed the connection, since we were waiting for FIN from the host.
So connections were leaked and eventually we couldn't open new ones.

**RFC Background**
Normally, in TCP client upon closing, i.e. issuing FIN, should be able to process data from the host.
It is so-called [Half-Closed connection in rfc9293](https://www.rfc-editor.org/rfc/rfc9293#name-half-closed-connections).
However, Zephyr does not support processing data after closing the connection.

According to the RFC, if client does not support Half-Closed connection, it should be issuing RST.
It is not done in Zephyr.

Neither was it ACK-ing new data, faking (mimicking) normal Half-Closed connection.

**Work done in Zephyr**
In the new version of Zephyr, https://github.com/zephyrproject-rtos/zephyr/releases/tag/v3.4.0, Zephyr started to fake normal Half-Closed connection. It is faking because data were not forward to the application, but at least they were ACK-ed, which lead to closing the connection. The change was introduced in refactoring FIN: https://github.com/zephyrproject-rtos/zephyr/pull/57509
So it works, device keeps sending data, which is great for us and for the clients.

However, RST still is not sent.
So I opened this PR (there you can also find Wireshark traces I collected) https://github.com/zephyrproject-rtos/zephyr/issues/61181

It lead to this PR (at the moment of writing it is a draft) https://github.com/zephyrproject-rtos/zephyr/pull/61353
It should fix closing behavior and RST in particular.

P.S. Both `3.4.0` and `main` (even more) in Zephyr contain many other important fixes for TCP, e.g.

- https://github.com/zephyrproject-rtos/zephyr/issues/53500
https://github.com/zephyrproject-rtos/zephyr/pull/53891 @kica-z  
They finally fixed `net_tcp: context->tcp == NULL` error message!!!

- https://github.com/zephyrproject-rtos/zephyr/pull/57995
https://github.com/zephyrproject-rtos/zephyr/pull/57202 (edited) 
two undefined behaviors

- https://github.com/zephyrproject-rtos/zephyr/issues/55641
https://github.com/zephyrproject-rtos/zephyr/pull/55775
Ignoring timeout in socket 

- https://github.com/zephyrproject-rtos/zephyr/issues/58828
https://github.com/zephyrproject-rtos/zephyr/pull/58905
Two possible crashes by dereferencing

- https://github.com/zephyrproject-rtos/zephyr/pull/60880
Fixing potential deadlock

And many others...

Which is SUPER important for a worldwide rollout, but it may also introduce new bugs, so we have to double down on testing!!!

