### PR TITLE
Hotfix/ehlpxt 1230 socket infinite loop

### DIFF
--- a/subsys/net/lib/http/http_client.c
+++ b/subsys/net/lib/http/http_client.c
@@ -11,7 +11,7 @@
  */
 
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(net_http, CONFIG_NET_HTTP_LOG_LEVEL);
+LOG_MODULE_REGISTER(net_http_client, CONFIG_NET_HTTP_LOG_LEVEL);
 
 #include <zephyr/kernel.h>
 #include <string.h>
@@ -406,7 +406,11 @@ static void http_client_init_parser(struct http_parser *parser,
 	settings->on_url = on_url;
 }
 
-static void http_data_final_null_resp(struct http_request *req)
+/* Report a NULL HTTP response to the caller.
+ * A NULL response is when the HTTP server intentionally closes the TLS socket (using FINACK)
+ * without sending any HTTP payload.
+ */
+static void http_report_null(struct http_request *req)
 {
 	if (req->internal.response.cb) {
 		NET_DBG("Calling callback for Final Data"
@@ -423,6 +427,28 @@ static void http_data_final_null_resp(struct http_request *req)
 		memset(req->internal.response.http_status, 0, HTTP_STATUS_STR_SIZE);
 
 		req->internal.response.cb(&req->internal.response, HTTP_DATA_FINAL,
+					  req->internal.user_data);
+	}
+}
+
+/* Report a completed HTTP transaction (with no error) to the caller */
+static void http_report_complete(struct http_request *req)
+{
+	if (req->internal.response.cb) {
+		NET_DBG("Calling callback for %zd len data", req->internal.response.data_len);
+		req->internal.response.cb(&req->internal.response, HTTP_DATA_FINAL,
+					  req->internal.user_data);
+	}
+}
+
+/* Report that some data has been received, but the HTTP transaction is still ongoing. */
+static void http_report_progress(struct http_request *req)
+{
+	if (req->internal.response.cb) {
+		NET_DBG("Calling callback for partitioned %zd len data",
+			req->internal.response.data_len);
+
+		req->internal.response.cb(&req->internal.response, HTTP_DATA_MORE,
 					  req->internal.user_data);
 	}
 }
@@ -452,24 +478,26 @@ static int http_wait_data(int sock, struct http_request *req, int32_t timeout)
 		ret = zsock_poll(fds, nfds, remaining_time);
 		if (ret == 0) {
 			LOG_DBG("Timeout");
-			goto finalize_data;
+			ret = -ETIMEDOUT;
+			goto error;
 		} else if (ret < 0) {
+			ret = -errno;
 			goto error;
 		}
 		if (fds[0].revents & (ZSOCK_POLLERR | ZSOCK_POLLNVAL)) {
+			ret = -errno;
 			goto error;
 		} else if (fds[0].revents & ZSOCK_POLLHUP) {
 			/* Connection closed */
-			LOG_DBG("Connection closed");
-			goto finalize_data;
+			goto closed;
 		} else if (fds[0].revents & ZSOCK_POLLIN) {
 			received = zsock_recv(sock, req->internal.response.recv_buf + offset,
 					      req->internal.response.recv_buf_len - offset, 0);
 			if (received == 0) {
 				/* Connection closed */
-				LOG_DBG("Connection closed");
-				goto finalize_data;
+				goto closed;
 			} else if (received < 0) {
+				ret = -errno;
 				goto error;
 			} else {
 				req->internal.response.data_len += received;
@@ -486,54 +514,41 @@ static int http_wait_data(int sock, struct http_request *req, int32_t timeout)
 				offset = 0;
 			}
 
-			if (req->internal.response.cb) {
-				bool notify = false;
-				enum http_final_call event;
-
-				if (req->internal.response.message_complete) {
-					NET_DBG("Calling callback for %zd len data",
-						req->internal.response.data_len);
-
-					notify = true;
-					event = HTTP_DATA_FINAL;
-				} else if (offset == 0) {
-					NET_DBG("Calling callback for partitioned %zd len data",
-						req->internal.response.data_len);
-
-					notify = true;
-					event = HTTP_DATA_MORE;
-				}
-
-				if (notify) {
-					req->internal.response.cb(&req->internal.response, event,
-								  req->internal.user_data);
-
-					/* Re-use the result buffer and start to fill it again */
-					req->internal.response.data_len = 0;
-					req->internal.response.body_frag_start = NULL;
-					req->internal.response.body_frag_len = 0;
-				}
-			}
-
 			if (req->internal.response.message_complete) {
-				ret = total_received;
+				http_report_complete(req);
 				break;
+			} else if (offset == 0) {
+				http_report_progress(req);
+
+				/* Re-use the result buffer and start to fill it again */
+				req->internal.response.data_len = 0;
+				req->internal.response.body_frag_start = NULL;
+				req->internal.response.body_frag_len = 0;
 			}
 		}
 
 	} while (true);
 
-	return ret;
+	return total_received;
 
-finalize_data:
-	ret = total_received;
+closed:
+	LOG_DBG("Connection closed");
 
-	http_data_final_null_resp(req);
-	return ret;
+	/* If connection was closed with no data sent, this is a NULL response, and is a special
+	 * case valid response.
+	 */
+	if (total_received == 0) {
+		http_report_null(req);
+		return total_received;
+	}
+
+	/* Otherwise, connection was closed mid-way through response, and this should be
+	 * considered an error.
+	 */
+	ret = -ECONNRESET;
 
 error:
-	LOG_DBG("Connection error (%d)", errno);
-	ret = -errno;
+	LOG_DBG("Connection error (%d)", ret);
 	return ret;
 }
 
@@ -731,9 +746,11 @@ int http_client_req(int sock, struct http_request *req,
 	total_recv = http_wait_data(sock, req, timeout);
 	if (total_recv < 0) {
 		NET_DBG("Wait data failure (%d)", total_recv);
-	} else {
-		NET_DBG("Received %d bytes", total_recv);
+		ret = total_recv;
+		goto out;
 	}
+
+	NET_DBG("Received %d bytes", total_recv);
 
 	return total_sent;
 

--- a/subsys/net/lib/http/http_client.c
+++ b/subsys/net/lib/http/http_client.c
@@ -29,9 +29,8 @@ LOG_MODULE_REGISTER(net_http_client, CONFIG_NET_HTTP_LOG_LEVEL);
 #define HTTP_CONTENT_LEN_SIZE 11
 #define MAX_SEND_BUF_LEN 192
 
-#define HTTP_CLIENT_SOCKET_POLL_TIMEOUT_MS 2000
-
-static int sendall(int sock, const void *buf, size_t len)
+static int sendall(int sock, const void *buf, size_t len,
+			const k_timepoint_t req_end_timepoint)
 {
 	while (len) {
 		ssize_t out_len = zsock_send(sock, buf, len, 0);
@@ -39,10 +38,13 @@ static int sendall(int sock, const void *buf, size_t len)
 		if ((out_len == 0) || (out_len < 0 && errno == EAGAIN)) {
 			struct zsock_pollfd pfd;
 			int pollres;
+			k_ticks_t req_timeout_ticks =
+				sys_timepoint_timeout(req_end_timepoint).ticks;
+			int req_timeout_ms = k_ticks_to_ms_floor32(req_timeout_ticks);
 
 			pfd.fd = sock;
 			pfd.events = ZSOCK_POLLOUT;
-			pollres = zsock_poll(&pfd, 1, HTTP_CLIENT_SOCKET_POLL_TIMEOUT_MS);
+			pollres = zsock_poll(&pfd, 1, req_timeout_ms);
 			if (pollres >= 0) {
 				continue;
 			} else {
@@ -61,6 +63,7 @@ static int sendall(int sock, const void *buf, size_t len)
 
 static int http_send_data(int sock, char *send_buf,
 			  size_t send_buf_max_len, size_t *send_buf_pos,
+			  const k_timepoint_t req_end_timepoint,
 			  ...)
 {
 	const char *data;
@@ -69,7 +72,7 @@ static int http_send_data(int sock, char *send_buf,
 	int end_of_data, remaining_len;
 	int sent = 0;
 
-	va_start(va, send_buf_pos);
+	va_start(va, req_end_timepoint);
 
 	data = va_arg(va, const char *);
 
@@ -94,7 +97,7 @@ static int http_send_data(int sock, char *send_buf,
 				LOG_HEXDUMP_DBG(send_buf, end_of_send,
 						"Data to send");
 
-				ret = sendall(sock, send_buf, end_of_send);
+				ret = sendall(sock, send_buf, end_of_send, req_end_timepoint);
 				if (ret < 0) {
 					NET_DBG("Cannot send %d bytes (%d)",
 						end_of_send, ret);
@@ -133,13 +136,14 @@ err:
 	return ret;
 }
 
-static int http_flush_data(int sock, const char *send_buf, size_t send_buf_len)
+static int http_flush_data(int sock, const char *send_buf, size_t send_buf_len,
+				const k_timepoint_t req_end_timepoint)
 {
 	int ret;
 
 	LOG_HEXDUMP_DBG(send_buf, send_buf_len, "Data to send");
 
-	ret = sendall(sock, send_buf, send_buf_len);
+	ret = sendall(sock, send_buf, send_buf_len, req_end_timepoint);
 	if (ret < 0) {
 		return ret;
 	}
@@ -453,29 +457,23 @@ static void http_report_progress(struct http_request *req)
 	}
 }
 
-static int http_wait_data(int sock, struct http_request *req, int32_t timeout)
+static int http_wait_data(int sock, struct http_request *req, const k_timepoint_t req_end_timepoint)
 {
 	int total_received = 0;
 	size_t offset = 0;
 	int received, ret;
 	struct zsock_pollfd fds[1];
 	int nfds = 1;
-	int32_t remaining_time = timeout;
-	int64_t timestamp = k_uptime_get();
 
 	fds[0].fd = sock;
 	fds[0].events = ZSOCK_POLLIN;
 
 	do {
-		if (timeout > 0) {
-			remaining_time -= (int32_t)k_uptime_delta(&timestamp);
-			if (remaining_time < 0) {
-				/* timeout, make poll return immediately */
-				remaining_time = 0;
-			}
-		}
+		k_ticks_t req_timeout_ticks =
+			sys_timepoint_timeout(req_end_timepoint).ticks;
+		int req_timeout_ms = k_ticks_to_ms_floor32(req_timeout_ticks);
 
-		ret = zsock_poll(fds, nfds, remaining_time);
+		ret = zsock_poll(fds, nfds, req_timeout_ms);
 		if (ret == 0) {
 			LOG_DBG("Timeout");
 			ret = -ETIMEDOUT;
@@ -562,6 +560,8 @@ int http_client_req(int sock, struct http_request *req,
 	int total_sent = 0;
 	int ret, total_recv, i;
 	const char *method;
+	k_timeout_t req_timeout = K_MSEC(timeout);
+	k_timepoint_t req_end_timepoint = sys_timepoint_calc(req_timeout);
 
 	if (sock < 0 || req == NULL || req->response == NULL ||
 	    req->recv_buf == NULL || req->recv_buf_len == 0) {
@@ -580,8 +580,9 @@ int http_client_req(int sock, struct http_request *req,
 	method = http_method_str(req->method);
 
 	ret = http_send_data(sock, send_buf, send_buf_max_len, &send_buf_pos,
-			     method, " ", req->url, " ", req->protocol,
-			     HTTP_CRLF, NULL);
+				req_end_timepoint, method,
+				" ", req->url, " ", req->protocol,
+				HTTP_CRLF, NULL);
 	if (ret < 0) {
 		goto out;
 	}
@@ -590,8 +591,8 @@ int http_client_req(int sock, struct http_request *req,
 
 	if (req->port) {
 		ret = http_send_data(sock, send_buf, send_buf_max_len,
-				     &send_buf_pos, "Host", ": ", req->host,
-				     ":", req->port, HTTP_CRLF, NULL);
+					&send_buf_pos, req_end_timepoint, "Host", ": ", req->host,
+					":", req->port, HTTP_CRLF, NULL);
 
 		if (ret < 0) {
 			goto out;
@@ -600,7 +601,7 @@ int http_client_req(int sock, struct http_request *req,
 		total_sent += ret;
 	} else {
 		ret = http_send_data(sock, send_buf, send_buf_max_len,
-				     &send_buf_pos, "Host", ": ", req->host,
+				     &send_buf_pos, req_end_timepoint, "Host", ": ", req->host,
 				     HTTP_CRLF, NULL);
 
 		if (ret < 0) {
@@ -611,7 +612,7 @@ int http_client_req(int sock, struct http_request *req,
 	}
 
 	if (req->optional_headers_cb) {
-		ret = http_flush_data(sock, send_buf, send_buf_pos);
+		ret = http_flush_data(sock, send_buf, send_buf_pos, req_end_timepoint);
 		if (ret < 0) {
 			goto out;
 		}
@@ -629,7 +630,7 @@ int http_client_req(int sock, struct http_request *req,
 		for (i = 0; req->optional_headers && req->optional_headers[i];
 		     i++) {
 			ret = http_send_data(sock, send_buf, send_buf_max_len,
-					     &send_buf_pos,
+					     &send_buf_pos, req_end_timepoint,
 					     req->optional_headers[i], NULL);
 			if (ret < 0) {
 				goto out;
@@ -641,7 +642,7 @@ int http_client_req(int sock, struct http_request *req,
 
 	for (i = 0; req->header_fields && req->header_fields[i]; i++) {
 		ret = http_send_data(sock, send_buf, send_buf_max_len,
-				     &send_buf_pos, req->header_fields[i],
+				     &send_buf_pos, req_end_timepoint, req->header_fields[i],
 				     NULL);
 		if (ret < 0) {
 			goto out;
@@ -652,7 +653,7 @@ int http_client_req(int sock, struct http_request *req,
 
 	if (req->content_type_value) {
 		ret = http_send_data(sock, send_buf, send_buf_max_len,
-				     &send_buf_pos, "Content-Type", ": ",
+				     &send_buf_pos, req_end_timepoint, "Content-Type", ": ",
 				     req->content_type_value, HTTP_CRLF, NULL);
 		if (ret < 0) {
 			goto out;
@@ -673,12 +674,13 @@ int http_client_req(int sock, struct http_request *req,
 			}
 
 			ret = http_send_data(sock, send_buf, send_buf_max_len,
-					     &send_buf_pos, "Content-Length", ": ",
-					     content_len_str, HTTP_CRLF,
-					     HTTP_CRLF, NULL);
+						&send_buf_pos, req_end_timepoint,
+						"Content-Length", ": ",
+						content_len_str, HTTP_CRLF,
+						HTTP_CRLF, NULL);
 		} else {
 			ret = http_send_data(sock, send_buf, send_buf_max_len,
-				     &send_buf_pos, HTTP_CRLF, NULL);
+				     &send_buf_pos, req_end_timepoint, HTTP_CRLF, NULL);
 		}
 
 		if (ret < 0) {
@@ -687,7 +689,7 @@ int http_client_req(int sock, struct http_request *req,
 
 		total_sent += ret;
 
-		ret = http_flush_data(sock, send_buf, send_buf_pos);
+		ret = http_flush_data(sock, send_buf, send_buf_pos, req_end_timepoint);
 		if (ret < 0) {
 			goto out;
 		}
@@ -711,7 +713,7 @@ int http_client_req(int sock, struct http_request *req,
 				length = req->payload_len;
 			}
 
-			ret = sendall(sock, req->payload, length);
+			ret = sendall(sock, req->payload, length, req_end_timepoint);
 			if (ret < 0) {
 				goto out;
 			}
@@ -720,7 +722,7 @@ int http_client_req(int sock, struct http_request *req,
 		}
 	} else {
 		ret = http_send_data(sock, send_buf, send_buf_max_len,
-				     &send_buf_pos, HTTP_CRLF, NULL);
+				     &send_buf_pos, req_end_timepoint, HTTP_CRLF, NULL);
 		if (ret < 0) {
 			goto out;
 		}
@@ -729,7 +731,7 @@ int http_client_req(int sock, struct http_request *req,
 	}
 
 	if (send_buf_pos > 0) {
-		ret = http_flush_data(sock, send_buf, send_buf_pos);
+		ret = http_flush_data(sock, send_buf, send_buf_pos, req_end_timepoint);
 		if (ret < 0) {
 			goto out;
 		}
@@ -743,7 +745,7 @@ int http_client_req(int sock, struct http_request *req,
 				&req->internal.parser_settings);
 
 	/* Request is sent, now wait data to be received */
-	total_recv = http_wait_data(sock, req, timeout);
+	total_recv = http_wait_data(sock, req, req_end_timepoint);
 	if (total_recv < 0) {
 		NET_DBG("Wait data failure (%d)", total_recv);
 		ret = total_recv;

--- a/subsys/net/lib/http/http_client.c
+++ b/subsys/net/lib/http/http_client.c
@@ -45,7 +45,9 @@ static int sendall(int sock, const void *buf, size_t len,
 			pfd.fd = sock;
 			pfd.events = ZSOCK_POLLOUT;
 			pollres = zsock_poll(&pfd, 1, req_timeout_ms);
-			if (pollres >= 0) {
+			if (pollres == 0) {
+				return -ETIMEDOUT;
+			} else if (pollres > 0) {
 				continue;
 			} else {
 				return -errno;


### PR DESCRIPTION
Sync `http_client` with Zephyr (cosmetic and edgecases) and fix the problem with socket polling infinite loop